### PR TITLE
Update owner field to 'swag'

### DIFF
--- a/.customink/catalog.yaml
+++ b/.customink/catalog.yaml
@@ -1,6 +1,6 @@
 name: swag-holiday
 
-owner: swag_core # team definitions at https://app.opslevel.com/teams
+owner: swag # team definitions at https://app.opslevel.com/teams
 
 purpose: # multiple choice
   # - do_not_track # demo testing personal - will not be tracked in catalog


### PR DESCRIPTION
This PR updates the owner field in `.customink/catalog.yaml` from `swag_core` to `swag` to align with the new naming convention.